### PR TITLE
fix subsequent install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ CONFIG_DIR="/Users/$user/.config/fcitx5"
 
 cd "$Resources"
 mkdir -p "$INSTALL_DIR"
-rm -rf "$APP_DIR"
+rm -rf "$APP_DIR/Contents/*"
 tar xjvf "Fcitx5-$ARCH.tar.bz2" -C "$INSTALL_DIR"
 xattr -dr com.apple.quarantine "$APP_DIR"
 codesign --force --sign - --deep "$APP_DIR"

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ chown -R "$user" "$CONFIG_DIR"
 
 if killall Fcitx5; then
   echo killed previously-installed Fctix5
+  exit 0
 fi
 
 ./register_im


### PR DESCRIPTION
As per my test, the behavior on macOS 14 is

```mermaid
flowchart
  nothing -->|create /Library/Input Methods/Fcitx5.app| installed
  installed -->|sudo TISRegisterInputSource| registered
  registered -->|TISEnableInputSource| enabled
  enabled -->|TISSelectInputSource| activated
  enabled -->|TISEnableInputSource| error
  activated -->|TISEnableInputSource| error
  error -->|remove Fcitx5 from All Input Sources| registered
```
* registered: Fcitx5 appears in Chinese, Simplified.
* enabled: Fcitx5 appears in All Input Sources and switch menu.
* error: Fcitx5 appears in All Input Sources but not switch menu, usable until switched out.
* activated: enabled and is current input method.

So on master if you install twice you will be in error state.
Please verify the graph and document behavior on your machine if not consistent.

PS: A full clean needs
* remove Fcitx5 from All Input Sources
* `rm -rf /Library/Input\ Methods/Fcitx5.app`
* logout 