### PR TITLE
async installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: SwiftyLab/setup-swift@latest
-
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 set -xeu
 
-date
+date 1>&2
 setopt NULL_GLOB
 
 user="$1"


### PR DESCRIPTION
Test procedure:
Put
```sh
sleep 5
exit 0 # or 1
```
after `setopt NULL_GLOB` in install.sh, then try cancel sudo or normal installation.
The mouse pointer should not be a spinning rainbow (but this previous behavior indicates installer **is** working, so we may make button color flash later).